### PR TITLE
Minor updates to Challenge 01

### DIFF
--- a/Challenge-01 - Deploy AHDS workspace and FHIR service/Readme.md
+++ b/Challenge-01 - Deploy AHDS workspace and FHIR service/Readme.md
@@ -63,7 +63,7 @@ In the first part of this challenge, you will
 
 <img src="../resources/docs/images/ARM_template_config2.png" height="420"> 
 
-**Note:** This deployment typically takes 20 minutes.
+**Note:** This deployment typically takes 20 minutes. You can work on step 2 during the deployment.
 
 Review [Step 1 in these instructions](../resources/docs/FHIR-Starter_ARM_template_README.md#step-1---initial-deployment) to learn more about the resources deployed with this ARM template.
 
@@ -83,9 +83,9 @@ Follow the instructions and return here when finished.
 ## What does success look like for Challenge-01?
 
 + Azure Health Data Services workspace and FHIR service deployed and available in Azure.
-+ FHIR-Proxy and FHIR Loader deployed in Azure for future challenges.
-+ Client application created in Azure Active Directory for use with Postman and your FHIR service.
-+ Postman set up and able to connect with the FHIR service.
++ Other Azure resources for future challenges successfully deployed. Template deployment must have no errors.
++ App registration created in Azure Active Directory for use with Postman and your FHIR service.
++ Postman set up and able to connect with your FHIR service.
   + Capability Statement from your FHIR service - received.
 
     ```json
@@ -104,7 +104,7 @@ Follow the instructions and return here when finished.
 
   + `POST AuthorizeGetToken` call in Postman to obtain an AAD access token - succeeded.
   + `POST Save Patient` call in Postman to populate FHIR service with a Patient Resource - succeeded.
-  + `GET List Patients` call in Postman to retrieve a bundle of all Patient Resources stored in FHIR service - succeeded.
+  + `GET List Patients` call in Postman to retrieve a bundle with at least one Patient Resource from your FHIR service - succeeded.
 
 ## Next Steps
 

--- a/Challenge-01 - Deploy AHDS workspace and FHIR service/Readme.md
+++ b/Challenge-01 - Deploy AHDS workspace and FHIR service/Readme.md
@@ -4,7 +4,7 @@
 
 Welcome to Challenge-01!
 
-In this challenge, you will deploy and use an **[Azure Health Data Services workspace](https://docs.microsoft.com/en-us/azure/healthcare-apis/workspace-overview)** containing a **[FHIR service](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/overview)** instance. In addition, you will set up **[Postman](https://www.postman.com/)** as your API testing tool for reading and writing data to and from your FHIR service.
+In this challenge, you will deploy and use an **[Azure Health Data Services workspace](https://docs.microsoft.com/azure/healthcare-apis/workspace-overview)** containing a **[FHIR service](https://docs.microsoft.com/azure/healthcare-apis/fhir/overview)** instance. In addition, you will set up **[Postman](https://www.postman.com/)** as your API testing tool for reading and writing data to and from your FHIR service.
 
 ## Learning Objectives for Challenge-01
 
@@ -17,7 +17,7 @@ By the end of this challenge you will be able to
 
 ## Background
 
-**FHIR service** is the core component for reading, writing, and querying structured health data in [Azure Health Data Services](https://docs.microsoft.com/en-us/azure/healthcare-apis/healthcare-apis-overview) (AHDS). You may have also heard of Azure API for FHIR, which was Microsoft's first generally available product for FHIR. For this training, we will be focusing on the new AHDS FHIR service, which has some big advantages over its predecessor (like transaction bundles, AHDS workspace level configuration, and performance improvements for search, import, and export). Many of the exercises in these challenges will work with Azure API for FHIR, but some will not. In this workshop, to take advantage of the latest health data products from Microsoft, we will be using the AHDS FHIR service.
+**FHIR service** is the core component for reading, writing, and querying structured health data in [Azure Health Data Services](https://docs.microsoft.com/azure/healthcare-apis/healthcare-apis-overview). You may have also heard of Azure API for FHIR, which was Microsoft's first generally available product for FHIR. For this training, we will be focusing on the new Azure Health Data Services FHIR service, which has some big advantages over its predecessor (like transaction bundles, workspace level configuration, and performance improvements for search, import, and export). Many of the exercises in these challenges will work with Azure API for FHIR, but some will not. In this workshop, to take advantage of the latest health data products from Microsoft, we will be using the FHIR service.
 
 ### Azure Health Data Services Workspace relationship with FHIR, DICOM, and MedTech Services
 
@@ -37,13 +37,13 @@ Before deploying to your Azure environment, please make sure that you have the f
 
 You will also need to have [Postman](https://www.getpostman.com/) installed - either the desktop or web client.
 
-## Step 1: Deploy AHDS workspace and FHIR service to your Azure environment
+## Step 1: Deploy Azure Health Data Services workspace and FHIR service to your Azure environment
 
 In the first part of this challenge, you will
 
 + Use a template to deploy resources with the Azure Portal. This template will deploy
-  + [Azure Health Data Services workspace](https://docs.microsoft.com/en-us/azure/healthcare-apis/workspace-overview)
-  + [FHIR service](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/overview)
+  + [Azure Health Data Services workspace](https://docs.microsoft.com/azure/healthcare-apis/workspace-overview)
+  + [FHIR service](https://docs.microsoft.com/azure/healthcare-apis/fhir/overview)
   + [FHIR Loader](https://github.com/microsoft/fhir-loader) (for Challenge-03)
   + [FHIR-Proxy](https://github.com/microsoft/fhir-proxy) (for Challenge-07)
 
@@ -51,7 +51,7 @@ In the first part of this challenge, you will
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fazure-health-data-services-workshop%2Fmain%2Fresources%2Fdeploy%2Fdeployfhirtrain.json)
 
-> __Important:__ In order to successfully deploy resources with this ARM template, the user must have [Owner](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) rights for the [Resource Group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal) where the components are deployed. Before running the ARM template, it is recommended to create a new resource group first and check to make sure that you have Owner permissions for that resource group. Once you confirm that you have Owner rights, then choose that resource group in the dropdown menu when you fill out the deployment form (see #3 below).
+> __Important:__ In order to successfully deploy resources with this ARM template, the user must have [Owner](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#owner) rights for the [Resource Group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal) where the components are deployed. Before running the ARM template, it is recommended to create a new resource group first and check to make sure that you have Owner permissions for that resource group. Once you confirm that you have Owner rights, then choose that resource group in the dropdown menu when you fill out the deployment form (see #3 below).
 
 2. Select or fill in the parameter values (see image below).
 

--- a/resources/deploy/assignpermissions.bicep
+++ b/resources/deploy/assignpermissions.bicep
@@ -127,7 +127,7 @@ resource fhirWorkspaceRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 }
 
 
-// API for FHIR
+// FHIR Service
 resource myApiforFhir 'Microsoft.HealthcareApis/services@2021-06-01-preview' existing = if (resourceType == 'FHIR') {
   name: resourceName
 }

--- a/resources/deploy/deployfhirtrain.bicep
+++ b/resources/deploy/deployfhirtrain.bicep
@@ -51,7 +51,7 @@ var proxyAppInsightName      = '${deploymentPrefix}${uniqueId}pxyai'
 var loaderAppInsightName     = '${deploymentPrefix}${uniqueId}ldrai'
 var loaderEventGridTopicName = '${deploymentPrefix}${uniqueId}ldrtopic'
 
-// API for FHIR artifact container registry name
+// FHIR service artifact container registry name
 var containerRegistryName   = '${deploymentPrefix}${uniqueId}cr'
 // -- containers to be created in export storage account
 var dataLakeContainerName = 'fhirdatalake'

--- a/resources/deploy/deployfhirtrain.bicep
+++ b/resources/deploy/deployfhirtrain.bicep
@@ -21,7 +21,7 @@ param fhirServerTenantName string = subscription().tenantId
 @description('Azure Region where the resources will be deployed. Default Value:  the resource group region')
 param resourceLocation string = resourceGroup().location
 @description('Enable the Consent Opt Out module in FHIR PROXY')
-param enableConsentOptOut bool = false
+param enableConsentOptOut bool = true
 @description('Enable the Date Sort module in FHIR PROXY')
 param enableDateSort bool = false
 @description('Enable the Participant Filter module in FHIR PROXY')

--- a/resources/deploy/deployfhirtrain.json
+++ b/resources/deploy/deployfhirtrain.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1318.3566",
-      "templateHash": "14354878437489154445"
+      "version": "0.5.6.12127",
+      "templateHash": "7226767830527493284"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     },
     "enableConsentOptOut": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
         "description": "Enable the Consent Opt Out module in FHIR PROXY"
       }
@@ -2127,8 +2127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -2333,8 +2333,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -2542,8 +2542,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -2752,8 +2752,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -2962,8 +2962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -3170,8 +3170,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {
@@ -3381,8 +3381,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "4993626785344344759"
+              "version": "0.5.6.12127",
+              "templateHash": "732080587006144038"
             }
           },
           "parameters": {

--- a/resources/docs/Postman_FHIR_service_README.md
+++ b/resources/docs/Postman_FHIR_service_README.md
@@ -4,7 +4,7 @@
 When testing data connectivity between [FHIR service](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/overview) and a remote client app, it is useful to have an API testing utility to send requests, view responses, and debug issues. One of the most popular API testing tools is [Postman](https://www.postman.com/), and in this guide we provide instructions plus a set of sample data files to help you get started with Postman as a testing platform for FHIR service in [Azure Health Data Services](https://docs.microsoft.com/en-us/azure/healthcare-apis/healthcare-apis-overview).
 
 ## Prerequisites
-+ [Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles) role in your Azure Subscription
++ [User Access Administrator](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator) role in your FHIR service resource group or Azure subscription
 + [Application Administrator](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#all-roles) role in your Azure Active Directory (AAD) tenant
 + **FHIR service** deployed. Information about FHIR service can be found [here](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/overview).
 + **Postman** installed - desktop or web client. Information about installing Postman is available [here](https://www.getpostman.com/). 
@@ -13,7 +13,7 @@ When testing data connectivity between [FHIR service](https://docs.microsoft.com
 To set up Postman for testing FHIR service, we'll walk through these steps:
 
 **Step 1:** Create an App Registration for Postman in AAD  
-**Step 2:** Assign Azure RBAC roles for Postman  
+**Step 2:** Assign FHIR Data Contributor role in Azure for Postman  
 **Step 3:** Import environment template and collection files into Postman  
 **Step 4:** Enter parameter values for the Postman environment  
 **Step 5:** Get an authorization token from AAD  
@@ -44,11 +44,11 @@ Before you can use Postman to make API calls to FHIR service, you will need to c
 7. Copy the secret **Value** and securely store it somewhere (you will need this when you configure your Postman environment). 
 <img src="./images/Screenshot_2022-02-15_142159_edit2.png" height="328">
 
-For more information on registering client applications in AAD for Azure Health Data Services, please see the [Authentication and Authorization for Azure Health Data Services](https://docs.microsoft.com/en-us/azure/healthcare-apis/authentication-authorization) documentation. 
+For more information on registering client applications in AAD for Azure Health Data Services, please see the [Authentication and Authorization for Azure Health Data Services](https://docs.microsoft.com/azure/healthcare-apis/authentication-authorization) documentation. 
 
-## Step 2 - Assign Azure RBAC roles for Postman
+## Step 2 - Assign FHIR Data Contributor role in Azure for Postman
 
-1. In Azure Portal, go to **Home** -> **Resource groups** and find the resource group containing your FHIR service instance. When in the resource group **Overview**, click on your FHIR service app name in the list. 
+1. In Azure Portal, go to **Home** -> **Resource groups** and find the resource group containing your FHIR service instance. When in the resource group **Overview**, click on your FHIR service name in the list. 
 <img src="./images/Screenshot_2022-02-15_142434_edit2.png" height="328">
 
 2. Go to the **Access Control (IAM)** blade. Click on the **Roles** tab.
@@ -78,7 +78,7 @@ For more information on registering client applications in AAD for Azure Health 
 10. Under the **Review + assign** tab, click **Review + assign**. 
 <img src="./images/Screenshot_2022-02-15_144245_edit2.png" height="328">
 
-For more information on assigning user/app roles, see [Configure Azure RBAC for Azure Health Data Services](https://docs.microsoft.com/en-us/azure/healthcare-apis/configure-azure-rbac).
+For more information on assigning user/app roles, see [Configure Azure RBAC for Azure Health Data Services](https://docs.microsoft.com/azure/healthcare-apis/configure-azure-rbac).
 
 ## Step 3 - Import environment and collection files into Postman
 
@@ -110,8 +110,8 @@ Now you will configure your Postman environment (`fhir-service`).
 - `tenantId` - AAD tenant ID (go to **AAD** -> **Overview** -> **Tenant ID**)
 - `clientId` - Application (client) ID for Postman client app (go to **AAD** -> **App registrations** -> **Name** -> **Overview** -> **Application (client) ID**) 
 - `clientSecret` - Client secret stored for Postman (see Step 1 #7 above) 
-- `fhirurl` - Azure API for FHIR endpoint - e.g. `https://<azure_api_for_fhir_app_name>.azurehealthcareapis.com` (go to **Resource Group** -> **Overview** -> **Name** -> **FHIR metadata endpoint** and copy *without* "/metadata" on the end)
-- `resource` - Azure API for FHIR endpoint - e.g. `https://<azure_api_for_fhir_app_name>.azurehealthcareapis.com` (same as `fhirurl`)
+- `fhirurl` - FHIR service endpoint - e.g. `https://<workspace-name>-<fhir-service-name>.azurehealthcareapis.com` (go to **Resource Group** -> **Overview** -> **Name** -> **FHIR metadata endpoint** and copy *without* "/metadata" on the end)
+- `resource` - FHIR service endpoint - e.g. `https://<workspace-name>-<fhir-service-name>.azurehealthcareapis.com` (same as `fhirurl`)
 
 Populate the above parameter values in your `fhir-service` Postman environment as shown below. Leave `bearerToken` blank. Make sure to click `Save` to retain the `fhir-service` environment values.  
 
@@ -166,10 +166,9 @@ __Note:__ Access tokens expire after 60 minutes. To obtain a token refresh, simp
 
 ### Resources 
 
-A tutorial for using Postman with FHIR service is available on [docs.microsoft.com](https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/use-postman).
+A tutorial for using Postman with FHIR service is available on [docs.microsoft.com](https://docs.microsoft.com/azure/healthcare-apis/fhir/use-postman).
  
 ### FAQ's / Issues 
 
-403 - Unauthorized:  Check the Azure RBAC for FHIR service ([link](https://docs.microsoft.com/en-us/azure/healthcare-apis/configure-azure-rbac)).
-
-  
+- Error with ```POST AuthorizeGetToken```: Ensure you selected your environment in Postman and that you saved it.
+- 403 - Unauthorized:  Check the Azure RBAC for FHIR service ([link](https://docs.microsoft.com/azure/healthcare-apis/configure-azure-rbac)).


### PR DESCRIPTION
A few small changes found while reviewing Challenge-01. I'm really proud of how this turned out with the repo consolidation!!! 😄

- User Access Administrator is needed to assign role assignments to resources
- A couple wording changes to align with the names of Azure
- Removing `en-us` from doc URLs is small but important in case a learner isn't in the US
- Changed ARM template to default enable `enableConsentOptOut` to avoid issues w/ learners in Challenge 07
- Removed AHDS acronym - this is only used internally and must not be used in public documentation because it dilutes the brand.